### PR TITLE
Fix bug with invalid client_id/client_secret

### DIFF
--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -9,9 +9,8 @@ class Opro::Oauth::TokenController < OproController
   def create
     # Find the client application
     application = Opro::Oauth::ClientApp.authenticate(params[:client_id], params[:client_secret])
-    auth_grant  = auth_grant_for(application, params)
 
-    if auth_grant.present?
+    if application.present? && (auth_grant = auth_grant_for(application, params)).present?
       auth_grant.refresh!
       render :json => { access_token:  auth_grant.access_token,
                         # http://tools.ietf.org/html/rfc6749#section-5.1


### PR DESCRIPTION
If an invalid `client_id` or `client_secret` is provided, the debug_msg was not being rendered.

Fixes https://github.com/opro/opro/issues/49
